### PR TITLE
Wrap call with closure in function to workaround xcodebuild crash

### DIFF
--- a/Helper/main.swift
+++ b/Helper/main.swift
@@ -28,8 +28,13 @@ registry.register(InitCommand())
 registry.register(ConfigCommand())
 registry.register(UpdateCommand())
 
-// Parse commands and run necessary processes
-registry.main(defaultVerb: "update") { error in
-    print("fuck")
-    exit(1)
+
+func runCommands() {
+    // Parse commands and run necessary processes
+    registry.main(defaultVerb: "update") { error in
+        print("fuck")
+        exit(1)
+    }
 }
+
+runCommands()


### PR DESCRIPTION
Crasher in `xcodebuild` with top-level closures prevented this from building.

This PR wraps the offensive top-level closure in a function.