### PR TITLE
Check for Cartfile

### DIFF
--- a/Helper/Cartfile.swift
+++ b/Helper/Cartfile.swift
@@ -10,5 +10,13 @@ import Foundation
 
 /// Creates empty `Cartfile`.
 internal func createCartfile(in directory: URL) throws {
+    
+    let fileManager = FileManager()
+    let cartfilePath = project.directory.appendingPathComponent("Cartfile").path
+    
+    guard fileManager.fileExists(atPath: cartfilePath) else {
+        return
+    }
+    
     try createFile(name: "Cartfile", in: directory)
 }

--- a/Helper/Cartfile.swift
+++ b/Helper/Cartfile.swift
@@ -14,7 +14,7 @@ internal func createCartfile(in directory: URL) throws {
     let fileManager = FileManager()
     let cartfilePath = project.directory.appendingPathComponent("Cartfile").path
     
-    guard fileManager.fileExists(atPath: cartfilePath) else {
+    guard !fileManager.fileExists(atPath: cartfilePath) else {
         return
     }
     


### PR DESCRIPTION
Checks for presence of `Cartfile` before generating one and blowing out the contents of the previous.