### PR TITLE
Add option to specify platforms of cross-platform framework

### DIFF
--- a/dn-m
+++ b/dn-m
@@ -495,6 +495,7 @@ def create_gitignore
     }
 end
 
+# TODO: Store build hardware, OS versions, etc. in Hash somewhere
 def create_travis(name, platforms)
 
     File.open('.travis.yml', 'w') { |file| 
@@ -502,7 +503,7 @@ def create_travis(name, platforms)
         file.puts("osx_image: xcode8")
         file.puts("env:")
         file.puts("  matrix:")
-        
+
         platforms.each do |platform|
 
             scheme = "#{name} #{platform}"

--- a/dn-m
+++ b/dn-m
@@ -314,11 +314,13 @@ def create_empty_header(path)
     FileUtils.touch(path)
 end
 
-def add_header_build_files(project, name, header_path)
+def add_header_build_files(
+    project, name, header_path, platforms=['iOS','macOS']
+)
     
     header_ref = project.main_group.new_file(header_path)
 
-    ['iOS', 'macOS'].each do |platform|
+    platforms.each do |platform|
         build_file = project.targets
             .find { |y| y.name == "#{name} #{platform}" }
             .add_file_references([header_ref], 'header_build_file')
@@ -328,7 +330,6 @@ end
 
 # =============================================================================
 # Targets
-# TODO: iOS macOS / framework / test
 # =============================================================================
 def configure_targets(project, name, platforms=['iOS', 'macOS'])
 
@@ -338,7 +339,6 @@ def configure_targets(project, name, platforms=['iOS', 'macOS'])
 
         # TODO: Store versions in Hash somewhere
         version = platform == 'iOS' ? '8.4' : '10.9'
-
         platform_symbol = platform == 'iOS' ? :ios : :osx
 
         primary_target = project.new_target(

--- a/dn-m
+++ b/dn-m
@@ -258,9 +258,9 @@ end
 # Schemes
 # =============================================================================
 # TODO: Add platform variables
-def configure_schemes(project, name)
-    share_schemes(project, name)
-    add_testable_entries(project, name)
+def configure_schemes(project, name, platforms=['iOS', 'macOS'])
+    share_schemes(project, name, platforms)
+    add_testable_entries(project, name, platforms)
 end
 
 # TODO: Add platform variables

--- a/dn-m
+++ b/dn-m
@@ -178,9 +178,9 @@ end
 # Build Configuration
 # TODO: Add platform variables
 # =============================================================================
-def configure_build_configuration_settings(project, name)
-    configure_project_build_configuration_settings(project, name)
-    configure_primary_build_configuration_settings(project, name)
+def configure_build_configuration_settings(project, name, platforms=['iOS', 'macOS'])
+    configure_project_build_configuration_settings(project, name, platforms)
+    configure_primary_build_configuration_settings(project, name, platforms)
     configure_tests_build_configuration_settings(project, name)
 end
 

--- a/dn-m
+++ b/dn-m
@@ -215,9 +215,9 @@ def configure_project_build_configuration_settings(project, name)
 end
 
 # TODO: Add platform variables
-def configure_primary_build_configuration_settings(project, name)
+def configure_primary_build_configuration_settings(project, name, platforms=['iOS', 'macOS'])
 
-    ['iOS', 'macOS'].each do |platform|
+    platforms.each do |platform|
 
         # FIXME: abstract away
         target = project.targets.find { |y| y.name == "#{name} #{platform}" }
@@ -237,7 +237,7 @@ def configure_primary_build_configuration_settings(project, name)
 end
 
 # TODO: Add platform variables
-def configure_tests_build_configuration_settings(project, name, platforms)
+def configure_tests_build_configuration_settings(project, name, platforms=['iOS', 'macOS'])
 
     platforms.each do |platform|
 

--- a/dn-m
+++ b/dn-m
@@ -264,9 +264,9 @@ def configure_schemes(project, name)
 end
 
 # TODO: Add platform variables
-def add_testable_entries(project, name)
+def add_testable_entries(project, name, platforms=['iOS','macOS'])
 
-    ['iOS', 'macOS'].each do |platform|
+    platforms.each do |platform|
         
         # FIXME: abstract away
         target = project.targets.find { |y| y.name == "#{name} #{platform} Tests" }

--- a/dn-m
+++ b/dn-m
@@ -630,7 +630,7 @@ class Helper
             c.option '--platforms', String, 'iOS or macOS'
             c.action do |args, options|
 
-                platforms = args.empty? ? ['iOS', 'macOS'] : args
+                platforms = args.empty? || (args.count ==1 && args.first == 'all') ? ['iOS', 'macOS'] : args
 
                 puts "args: #{args}"
                 puts "options: #{options}"

--- a/dn-m
+++ b/dn-m
@@ -237,9 +237,9 @@ def configure_primary_build_configuration_settings(project, name)
 end
 
 # TODO: Add platform variables
-def configure_tests_build_configuration_settings(project, name)
+def configure_tests_build_configuration_settings(project, name, platforms)
 
-    ['iOS', 'macOS'].each do |platform|
+    platforms.each do |platform|
 
         target = project.targets.find { |y| y.name == "#{name} #{platform} Tests" }
 

--- a/dn-m
+++ b/dn-m
@@ -152,7 +152,7 @@ def init(name, platforms)
     project = new_project(name)
     configure_PBXGroups(project, name)
     add_info_plist_refs(project, name)
-    configure_targets(project, name)
+    configure_targets(project, name, platforms)
     configure_header(project, name)
     configure_schemes(project, name)
     configure_build_configuration_settings(project, name)
@@ -330,9 +330,9 @@ end
 # Targets
 # TODO: iOS macOS / framework / test
 # =============================================================================
-def configure_targets(project, name)
+def configure_targets(project, name, platforms=['iOS', 'macOS'])
 
-    ['iOS', 'macOS'].each do |platform|
+    platforms.each do |platform|
 
         target_name = "#{name} #{platform}"
 
@@ -362,7 +362,6 @@ end
 # =============================================================================
 # Supporting Files
 # =============================================================================
-
 def add_info_plist_refs(project, name)
     [name, "#{name}Tests"].each do |x|
         project[x]["Supporting Files"].new_file("#{x}/Info.plist")

--- a/dn-m
+++ b/dn-m
@@ -68,7 +68,7 @@ def create_carthage_script_phase(project, name)
         t = target(project, name, platform, true)
 
         # Make sure there's only one shell script phase
-        if t.shell_script_build_phases.count == 0 then
+        if t.shell_script_build_phases.empty? then
             script_phase = t.new_shell_script_build_phase
             script_phase.shell_script = '/usr/local/bin/carthage copy-frameworks'
         end
@@ -135,11 +135,11 @@ end
 # =============================================================================
 # init command
 # =============================================================================
-def init(name)
+def init(name, platforms)
 
     path = "#{Dir.pwd}/#{name}.xcodeproj"
 
-    if Dir.exist?(path) then
+    unless !Dir.exist?(path) then
         puts "There's already a project here!"
         return
     end
@@ -490,18 +490,40 @@ def create_gitignore
     }
 end
 
-def create_travis(name)
+def create_travis(name, platforms)
+
+
+
     File.open('.travis.yml', 'w') { |file| 
         file.puts("language: objective-c")
         file.puts("osx_image: xcode8")
         file.puts("env:")
         file.puts("  matrix:")
-        file.puts("    - DESTINATION=\"platform=iOS Simulator,OS=9.3,name=iPad 2\"")
-        file.puts("      SCHEME=\"#{name}\"")
-        file.puts("    - DESTINATION=\"platform=iOS Simulator,OS=10.0,name=iPad Pro (12.9 inch)\"")
-        file.puts("      SCHEME=\"#{name}\"")
-        file.puts("    - DESTINATION=\"platform=OS X\"")
-        file.puts("      SCHEME=\"#{name}Mac\"")
+        
+        platforms.each do |platform|
+
+            scheme = "#{name} #{platform}"
+
+            case platform
+            when 'iOS'
+                
+                file.puts(
+                    "    - DESTINATION=\"platform=iOS Simulator,OS=9.3,name=iPad 2\""
+                )
+                
+                file.puts("      SCHEME=\"#{scheme}\"")
+                
+                file.puts(
+                    "    - DESTINATION=\"platform=iOS Simulator,OS=10.0,name=iPad Pro (12.9 inch)\""
+                )
+
+                file.puts("      SCHEME=\"#{name}\"")
+
+            when 'macOS'
+                file.puts("    - DESTINATION=\"platform=OS X\"")
+                file.puts("      SCHEME=\"#{scheme}\"")            
+        end
+
         file.puts()
         file.puts("before_script: if [ -f ./Cartfile ]; then carthage update; fi;")
         file.puts()
@@ -585,10 +607,19 @@ class Helper
         end
 
         command :init do |c|
-            c.syntax = 'init'
+            c.syntax = 'init [-a | -f]'
             c.description = 'Create a new project'
+            c.option '--platforms', String, 'iOS or macOS'
             c.action do |args, options|
-                init($project_name)
+
+                platforms = args.empty? ? ['iOS', 'macOS'] : args
+
+                puts "args: #{args}"
+                puts "options: #{options}"
+
+                puts "Platforms to build: #{platforms}"
+
+                init($project_name, platforms)
             end
         end
 

--- a/dn-m
+++ b/dn-m
@@ -47,7 +47,10 @@ def update_carthage
     system('carthage update')
 end
 
+# TODO: Add knowledge of frameworks!
 def add_framework_search_paths(project, name)
+
+    # Instead, gather the targets, and extract platforms
 
     ['iOS', 'macOS'].each do |platform|
         [true, false].each do |isTest|
@@ -109,6 +112,8 @@ def frameworks()
 
     Dir.chdir('Carthage/Build')
     result = Hash.new
+
+    # Carthage may not be built yet
     carthage_platforms.each do |platform|
         Dir.chdir(platform)
         result[from_carthage_platform(platform)] = Dir.entries('.')
@@ -146,16 +151,21 @@ def init(name, platforms)
         return
     end
 
+    # Create environment
     git_init
     config(name, platforms)
     create_file_structure(name)
+
+    # Create xcodeproj
     project = new_project(name)
     configure_PBXGroups(project, name)
     add_info_plist_refs(project, name)
     configure_targets(project, name, platforms)
-    configure_header(project, name)
-    configure_schemes(project, name)
-    configure_build_configuration_settings(project, name)
+    configure_header(project, name, platforms)
+    configure_schemes(project, name, platforms)
+    configure_build_configuration_settings(project, name, platforms)
+
+    # Save xcodeproj
     project.save
 end
 
@@ -178,10 +188,10 @@ end
 # Build Configuration
 # TODO: Add platform variables
 # =============================================================================
-def configure_build_configuration_settings(project, name, platforms=['iOS', 'macOS'])
-    configure_project_build_configuration_settings(project, name, platforms)
+def configure_build_configuration_settings(project, name, platforms)
+    configure_project_build_configuration_settings(project, name)
     configure_primary_build_configuration_settings(project, name, platforms)
-    configure_tests_build_configuration_settings(project, name)
+    configure_tests_build_configuration_settings(project, name, platforms)
 end
 
 def configure_project_build_configuration_settings(project, name) 
@@ -215,7 +225,7 @@ def configure_project_build_configuration_settings(project, name)
 end
 
 # TODO: Add platform variables
-def configure_primary_build_configuration_settings(project, name, platforms=['iOS', 'macOS'])
+def configure_primary_build_configuration_settings(project, name, platforms)
 
     platforms.each do |platform|
 
@@ -237,7 +247,7 @@ def configure_primary_build_configuration_settings(project, name, platforms=['iO
 end
 
 # TODO: Add platform variables
-def configure_tests_build_configuration_settings(project, name, platforms=['iOS', 'macOS'])
+def configure_tests_build_configuration_settings(project, name, platforms)
 
     platforms.each do |platform|
 
@@ -258,13 +268,13 @@ end
 # Schemes
 # =============================================================================
 # TODO: Add platform variables
-def configure_schemes(project, name, platforms=['iOS', 'macOS'])
+def configure_schemes(project, name, platforms)
     share_schemes(project, name, platforms)
     add_testable_entries(project, name, platforms)
 end
 
 # TODO: Add platform variables
-def add_testable_entries(project, name, platforms=['iOS','macOS'])
+def add_testable_entries(project, name, platforms)
 
     platforms.each do |platform|
         
@@ -290,7 +300,7 @@ def testable_ref(test_target)
 end
 
 # TODO: Add platform variables
-def share_schemes(project, name, platforms=['iOS','macOS'])
+def share_schemes(project, name, platforms)
     project.recreate_user_schemes(true)
     
     platforms.each do |platform|
@@ -304,19 +314,17 @@ end
 # Header
 # TODO: iOS macOS / framework / app options
 # =============================================================================
-def configure_header(project, name)
+def configure_header(project, name, platforms)
     header_path = "#{name}/#{name}.h"
     create_empty_header(header_path)
-    add_header_build_files(project, name, header_path)
+    add_header_build_files(project, name, header_path, platforms)
 end
 
 def create_empty_header(path)
     FileUtils.touch(path)
 end
 
-def add_header_build_files(
-    project, name, header_path, platforms=['iOS','macOS']
-)
+def add_header_build_files(project, name, header_path, platforms)
     
     header_ref = project.main_group.new_file(header_path)
 
@@ -331,7 +339,7 @@ end
 # =============================================================================
 # Targets
 # =============================================================================
-def configure_targets(project, name, platforms=['iOS', 'macOS'])
+def configure_targets(project, name, platforms)
 
     platforms.each do |platform|
 

--- a/dn-m
+++ b/dn-m
@@ -290,10 +290,10 @@ def testable_ref(test_target)
 end
 
 # TODO: Add platform variables
-def share_schemes(project, name)
+def share_schemes(project, name, platforms=['iOS','macOS'])
     project.recreate_user_schemes(true)
     
-    ['iOS', 'macOS'].each do |platform|
+    platforms.each do |platform|
         Xcodeproj::XCScheme.share_scheme(
             "#{Dir.pwd}/#{name}.xcodeproj", "#{name} #{platform}"
         )

--- a/dn-m
+++ b/dn-m
@@ -571,7 +571,7 @@ def create_readme(name, platforms)
 
     puts "Readme for platforms: #{platforms}"
 
-    platform_phrase = platforms.count == 1 ? platforms.first : platforms.join(' or ')
+    platform_phrase = platforms.join(' or ')
 
     puts "Platform phrase: #{platform_phrase}"
 

--- a/dn-m
+++ b/dn-m
@@ -137,6 +137,8 @@ end
 # =============================================================================
 def init(name, platforms)
 
+    puts "Initializing for platforms: #{platforms}"
+
     path = "#{Dir.pwd}/#{name}.xcodeproj"
 
     unless !Dir.exist?(path) then
@@ -145,7 +147,7 @@ def init(name, platforms)
     end
 
     git_init
-    config(name)
+    config(name, platforms)
     create_file_structure(name)
     project = new_project(name)
     configure_PBXGroups(project, name)
@@ -448,13 +450,16 @@ end
 # =============================================================================
 # config command
 # =============================================================================
-def config(name)
+def config(name, platforms=['iOS', 'macOS'])
+
+    puts "Configuring for platforms: #{platforms}"
+
     create_gitignore
-    create_travis(name)
+    create_travis(name, platforms) # find platforms
     create_swift_lint
     create_hound
     create_cartfile
-    create_readme(name)
+    create_readme(name, platforms)
 end
 
 def create_gitignore
@@ -492,8 +497,6 @@ end
 
 def create_travis(name, platforms)
 
-
-
     File.open('.travis.yml', 'w') { |file| 
         file.puts("language: objective-c")
         file.puts("osx_image: xcode8")
@@ -522,6 +525,7 @@ def create_travis(name, platforms)
             when 'macOS'
                 file.puts("    - DESTINATION=\"platform=OS X\"")
                 file.puts("      SCHEME=\"#{scheme}\"")            
+            end
         end
 
         file.puts()
@@ -563,7 +567,13 @@ def create_cartfile
     FileUtils.touch('Cartfile')
 end
 
-def create_readme(name)
+def create_readme(name, platforms)
+
+    puts "Readme for platforms: #{platforms}"
+
+    platform_phrase = platforms.count == 1 ? platforms.first : platforms.join(' or ')
+
+    puts "Platform phrase: #{platform_phrase}"
 
     File.open('README.md', 'w') { |file| 
         file.puts("# #{name}")
@@ -577,11 +587,11 @@ def create_readme(name)
         file.puts("## Integration")
         file.puts()
         file.puts("### Carthage")
-        file.puts("Integrate **#{name}** into your macOS or iOS project with [Carthage](https://github.com/Carthage/Carthage).")
+        file.puts("Integrate **#{name}** into your #{platform_phrase} project with [Carthage](https://github.com/Carthage/Carthage).")
         file.puts()
         file.puts("1. Follow [these instructions](https://github.com/Carthage/Carthage#installing-carthage) to install Carthage, if necessary.")
         file.puts("2. Add `github \"dn-m/#{name}\"` to your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile).")
-        file.puts("3. Follow [these instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) to integrate **#{name}** into your macOS or iOS project.")
+        file.puts("3. Follow [these instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) to integrate **#{name}** into your #{platform_phrase} project.")
         file.puts()
         file.puts("---")
         file.puts()


### PR DESCRIPTION
With `dn-m init --platforms [iOS | macOS | all]`, defaulting to `all`.